### PR TITLE
Renode: Add build number and build string

### DIFF
--- a/renode/meta_add_build_string.patch
+++ b/renode/meta_add_build_string.patch
@@ -1,0 +1,11 @@
+--- meta.yaml
++++ meta.yaml
+@@ -16,6 +16,8 @@
+     missing_dso_whitelist:
+         # This library comes with .NET
+         - "$SYSROOT/System32/mscoree.dll" [win]
++    number: {{ environ.get('DATE_NUM') }}
++    string: {{ environ.get('DATE_STR') }}
+ 
+ requirements:
+     build:

--- a/renode/prescript..sh
+++ b/renode/prescript..sh
@@ -25,7 +25,11 @@ patch-func meta.yaml meta_headless.patch
 patch-func build.sh build_without_gui.patch
 patch-func bld.bat build_without_gui_win.patch
 
+# Add build number and build string
+patch-func meta.yaml meta_add_build_string.patch
+
 # Clean the recipe
+rm meta_add_build_string.patch
 rm meta_add_travis_patches.patch
 rm meta_headless.patch
 rm build_without_gui.patch


### PR DESCRIPTION
By default build string is `0` which may break uploading. After the change `DATE_STR` will be used like in other `litex-conda-*` recipes.