### PR TITLE
Fix paths in `conda-ci` and remove `scripts` submodule

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -32,8 +32,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #2
@@ -44,8 +42,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #3
@@ -56,8 +52,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #4
@@ -68,8 +62,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #5
@@ -80,8 +72,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #6
@@ -93,8 +83,6 @@ jobs:
       SKIP: "true"  # See https://github.com/hdl/conda-misc/issues/29
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #7
@@ -106,8 +94,6 @@ jobs:
       SKIP: "true"  # See https://github.com/hdl/conda-misc/issues/29
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #8
@@ -118,8 +104,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #9
@@ -130,8 +114,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - run: brew install coreutils
       - uses: hdl/conda-ci@master
 
@@ -143,8 +125,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #11
@@ -155,8 +135,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #12
@@ -168,8 +146,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #13
@@ -180,22 +156,27 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
+
 
   master-package:
     runs-on: "ubuntu-20.04"
     env:
       OS_NAME: "linux"
+      CI_SCRIPTS_REL_PATH: "conda-ci"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          repository: hdl/conda-ci
+          ref: master
+          path: ${{ env.CI_SCRIPTS_REL_PATH }}
       - uses: actions/setup-python@v1
       - uses: BSFishy/pip-action@v1
         with:
           packages: urllib3
       - run: |
-          bash .github/scripts/install.sh
-          python .github/scripts/wait-for-statuses.py
+          # Required internally by the scripts to locate other scripts.
+          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH"
+          bash $CI_SCRIPTS_PATH/install.sh
+          python $CI_SCRIPTS_PATH/wait-for-statuses.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "conda-ci"]
-	path = .github/scripts
-	url = https://github.com/hdl/conda-ci.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ To build a package similarly to how the packages are built in the CI it is
 recommended to pass the following optional arguments:
 * `--channels litex-hub` – to search for build dependencies in the LiteX-Hub
   channel in addition to the recipe-specific channels (from its `condarc` file),
-* `--packages conda-build=3.20.3 python=3.7` – to use the same versions of
+* `--packages python=3.7` – to use the same versions of
   packages that influence building as in the CI.
 
 After preparing, the output `DIRECTORY` will contain subdirectories:
@@ -208,7 +208,7 @@ PREPARED_RECIPE_OUTPUTDIR=${PREPARED_RECIPE_OUTPUTDIR:-cbp-outdir}
 RECIPE_PATH=${RECIPE_PATH:-renode}
 
 # Prepare the RECIPE with `conda-build-prepare`
-ADDITIONAL_PACKAGES="conda-build=3.20.3 python=3.7"
+ADDITIONAL_PACKAGES="python=3.7"
 python3 -m conda_build_prepare               \
             --channels litex-hub             \
             --packages $ADDITIONAL_PACKAGES  \


### PR DESCRIPTION
The same changes as in hdl/conda-eda#152.

Let's see if the CI builds at least a few jobs properly to make sure there are no silly mistakes.